### PR TITLE
Fix StatPlus

### DIFF
--- a/StatPlus_mac_LE/StatPlus_mac_LE.download.recipe
+++ b/StatPlus_mac_LE/StatPlus_mac_LE.download.recipe
@@ -48,6 +48,18 @@
       <key>Processor</key>
       <string>Unarchiver</string>
     </dict>
+    <!-- Check code signature -->
+    <dict>
+      <key>Processor</key>
+      <string>CodeSignatureVerifier</string>
+      <key>Arguments</key>
+      <dict>
+        <key>input_path</key>
+        <string>%RECIPE_CACHE_DIR%/%NAME%/StatPlus.app</string>
+        <key>requirement</key>
+        <string>anchor apple generic and identifier "com.analystsoft.mst.pro2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "58ZUUA887T")</string>
+      </dict>
+    </dict>
   </array>   
 </dict>
 </plist>

--- a/StatPlus_mac_LE/StatPlus_mac_LE.download.recipe
+++ b/StatPlus_mac_LE/StatPlus_mac_LE.download.recipe
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple/DTD PLIST 1.0//EN" "http://apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>Attribution</key>
-  <dict>
-    <key>Copyright</key>
-    <string>University of Oxford 2016</string>
-    <key>Author</key>
-    <dict>
-      <key>Name</key>
-      <string>Christopher Beard</string>
-      <key>Email</key>
-      <string>christopher.beard at it.ox.ac.uk</string>
-      <key>Github</key>
-      <string>cdbeard</string>
-    </dict>
-  </dict>
-  <key>Description</key>
-  <string>Downloads the latest version of StatPlus:mac LE</string>
-  <key>Identifier</key>
-  <string>uk.ac.ox.orchard.download.StatPlus_mac_LE</string>
-  <key>Input</key>
-  <dict>
-    <key>DOWNLOAD_URL</key>
-    <string>http://download.analystsoft.com/statplusmacle.zip</string>
-    <key>NAME</key>
-    <string>StatPlus_mac_LE</string>
-  </dict>
-  <key>MinimumVersion</key>
-  <string>0.2.0</string>
-  <key>Process</key>
-  <array>
-    <dict>
-      <key>Processor</key>
-      <string>URLDownloader</string>
-      <key>Arguments</key>
-      <dict>
-        <key>url</key>
-        <string>%DOWNLOAD_URL%</string>
-      </dict>
-    </dict>  
-    <dict>
-      <key>Processor</key>
-      <string>EndOfCheckPhase</string>
-    </dict>
-    <dict>
-      <key>Processor</key>
-      <string>Unarchiver</string>
-    </dict>
-    <!-- Check code signature -->
-    <dict>
-      <key>Processor</key>
-      <string>CodeSignatureVerifier</string>
-      <key>Arguments</key>
-      <dict>
-        <key>input_path</key>
-        <string>%RECIPE_CACHE_DIR%/%NAME%/StatPlus.app</string>
-        <key>requirement</key>
-        <string>anchor apple generic and identifier "com.analystsoft.mst.pro2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "58ZUUA887T")</string>
-      </dict>
-    </dict>
-  </array>   
-</dict>
+	<dict>
+		<key>Attribution</key>
+		<dict>
+			<key>Copyright</key>
+			<string>University of Oxford 2016</string>
+			<key>Author</key>
+			<dict>
+				<key>Name</key>
+				<string>Christopher Beard</string>
+				<key>Email</key>
+				<string>christopher.beard at it.ox.ac.uk</string>
+				<key>Github</key>
+				<string>cdbeard</string>
+			</dict>
+		</dict>
+		<key>Description</key>
+		<string>Downloads the latest version of StatPlus:mac LE</string>
+		<key>Identifier</key>
+		<string>uk.ac.ox.orchard.download.StatPlus_mac_LE</string>
+		<key>Input</key>
+		<dict>
+			<key>DOWNLOAD_URL</key>
+			<string>http://download.analystsoft.com/statplusmacle.zip</string>
+			<key>NAME</key>
+			<string>StatPlus_mac_LE</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>0.2.0</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+				<key>Arguments</key>
+				<dict>
+					<key>url</key>
+					<string>%DOWNLOAD_URL%</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>Unarchiver</string>
+			</dict>
+			<!-- Check code signature -->
+			<dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+				<key>Arguments</key>
+				<dict>
+					<key>input_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/StatPlus.app</string>
+					<key>requirement</key>
+					<string>anchor apple generic and identifier "com.analystsoft.mst.pro2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "58ZUUA887T")</string>
+				</dict>
+			</dict>
+		</array>
+	</dict>
 </plist>

--- a/StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe
+++ b/StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe
@@ -49,48 +49,9 @@
   <key>MinimumVersion</key>
   <string>0.2.0</string>
   <key>ParentRecipe</key>
-  <string>uk.ac.ox.orchard.download.StatPlus_mac_LE</string>
+  <string>uk.ac.ox.orchard.pkg.StatPlus_mac_LE</string>
   <key>Process</key>
   <array>
-    <dict>
-      <key>Processor</key>
-      <string>EndOfCheckPhase</string>
-    </dict>
-    <!-- Check code signature -->
-    <dict>
-      <key>Processor</key>
-      <string>CodeSignatureVerifier</string>
-      <key>Arguments</key>
-      <dict>
-        <key>input_path</key>
-        <string>%RECIPE_CACHE_DIR%/%NAME%/StatPlusMacLE.dmg/StatPlus.app</string>
-        <key>requirement</key>
-        <string>anchor apple generic and identifier "com.analystsoft.mst.pro2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "58ZUUA887T")</string>
-      </dict>
-    </dict>
-    <!-- Extract version -->
-    <dict>
-      <key>Processor</key>
-      <string>AppDmgVersioner</string>
-      <key>Arguments</key>
-      <dict>
-        <key>dmg_path</key>
-        <string>%RECIPE_CACHE_DIR%/%NAME%/StatPlusMacLE.dmg</string>
-      </dict>
-    </dict>
-		<!-- Add version to pkginfo -->
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-		</dict>  
 		<!-- Import into munki -->
 		<dict>
 			<key>Processor</key>
@@ -98,7 +59,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%found_filename%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe
+++ b/StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe
@@ -1,69 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple/DTD PLIST 1.0//EN" "http://apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>Attribution</key>
-  <dict>
-    <key>Copyright</key>
-    <string>University of Oxford 2016</string>
-    <key>Author</key>
-    <dict>
-      <key>Name</key>
-      <string>Christopher Beard</string>
-      <key>Email</key>
-      <string>christopher.beard at it.ox.ac.uk</string>
-      <key>Github</key>
-      <string>cdbeard</string>
-    </dict>
-  </dict>
-  <key>Description</key>
-  <string>Downloads latest version of StatPlus:mac LE and imports into Munki</string>
-  <key>Identifier</key>
-  <string>uk.ac.ox.orchard.munki.StatPlus_mac_LE</string>
-  <key>Input</key>
-  <dict>
-    <key>NAME</key>
-    <string>StatPlus_mac_LE</string>
-    <key>MUNKI_REPO_SUBDIR</key>
-    <string>%NAME%</string>
-    <key>pkginfo</key>
-    <dict>
-      <key>catalogs</key>
-      <array>
-        <string>testing</string>
-      </array>  
-      <key>category</key>
-      <string>Scientific</string>
-      <key>description</key>
-      <string>Statistics analysis tool, primarly for Microsoft Excel but can be run standalone. Free LE version which can be licensed to Professional version.</string>
-      <key>developer</key>
-      <string>AnalystSoft</string>
-      <key>display_name</key>
-      <string>StatPlus:mac LE</string>
-      <key>name</key>
-      <string>%NAME%</string>
-      <key>unattended_install</key>
-      <true/>
-    </dict>
-  </dict>
-  <key>MinimumVersion</key>
-  <string>0.2.0</string>
-  <key>ParentRecipe</key>
-  <string>uk.ac.ox.orchard.pkg.StatPlus_mac_LE</string>
-  <key>Process</key>
-  <array>
-		<!-- Import into munki -->
+	<dict>
+		<key>Attribution</key>
 		<dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-			<key>Arguments</key>
+			<key>Copyright</key>
+			<string>University of Oxford 2016</string>
+			<key>Author</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%found_filename%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>Name</key>
+				<string>Christopher Beard</string>
+				<key>Email</key>
+				<string>christopher.beard at it.ox.ac.uk</string>
+				<key>Github</key>
+				<string>cdbeard</string>
 			</dict>
-		</dict> 
-  </array>   
-</dict>
+		</dict>
+		<key>Description</key>
+		<string>Downloads latest version of StatPlus:mac LE and imports into Munki</string>
+		<key>Identifier</key>
+		<string>uk.ac.ox.orchard.munki.StatPlus_mac_LE</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>StatPlus_mac_LE</string>
+			<key>MUNKI_REPO_SUBDIR</key>
+			<string>%NAME%</string>
+			<key>pkginfo</key>
+			<dict>
+				<key>catalogs</key>
+				<array>
+					<string>testing</string>
+				</array>
+				<key>category</key>
+				<string>Scientific</string>
+				<key>description</key>
+				<string>Statistics analysis tool, primarly for Microsoft Excel but can be run standalone. Free LE version which can be licensed to Professional version.</string>
+				<key>developer</key>
+				<string>AnalystSoft</string>
+				<key>display_name</key>
+				<string>StatPlus:mac LE</string>
+				<key>name</key>
+				<string>%NAME%</string>
+				<key>unattended_install</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>0.2.0</string>
+		<key>ParentRecipe</key>
+		<string>uk.ac.ox.orchard.pkg.StatPlus_mac_LE</string>
+		<key>Process</key>
+		<array>
+			<!-- Import into munki -->
+			<dict>
+				<key>Processor</key>
+				<string>MunkiImporter</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%found_filename%</string>
+					<key>repo_subdirectory</key>
+					<string>%MUNKI_REPO_SUBDIR%</string>
+				</dict>
+			</dict>
+		</array>
+	</dict>
 </plist>

--- a/StatPlus_mac_LE/StatPlus_mac_LE.pkg.recipe
+++ b/StatPlus_mac_LE/StatPlus_mac_LE.pkg.recipe
@@ -39,7 +39,7 @@
 					<key>app_path</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
 					<key>pkg_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
 				</dict>
 			</dict>
 			<dict>

--- a/StatPlus_mac_LE/StatPlus_mac_LE.pkg.recipe
+++ b/StatPlus_mac_LE/StatPlus_mac_LE.pkg.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple/DTD PLIST 1.0//EN" "http://apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Attribution</key>
+		<dict>
+			<key>Copyright</key>
+			<string>University of Oxford 2016</string>
+			<key>Author</key>
+			<dict>
+				<key>Name</key>
+				<string>Christopher Beard</string>
+				<key>Email</key>
+				<string>christopher.beard at it.ox.ac.uk</string>
+				<key>Github</key>
+				<string>cdbeard</string>
+			</dict>
+		</dict>
+		<key>Description</key>
+		<string>Downloads latest version of StatPlus:mac LE and creates a pkg</string>
+		<key>Identifier</key>
+		<string>uk.ac.ox.orchard.pkg.StatPlus_mac_LE</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>StatPlus_mac_LE</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>0.2.0</string>
+		<key>ParentRecipe</key>
+		<string>uk.ac.ox.orchard.download.StatPlus_mac_LE</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>AppPkgCreator</string>
+				<key>Arguments</key>
+				<dict>
+					<key>app_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+					<key>pkg_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>FileFinder</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pattern</key>
+					<string>%RECIPE_CACHE_DIR%/*.pkg</string>
+				</dict>
+			</dict>
+		</array>
+	</dict>
+</plist>


### PR DESCRIPTION
StatPlus changed from `.zip/.dmg/.app` to a `.zip/.app` and the recipe was failing since there's no more DMG.

Because it's just a .app in a .zip I added a pkg recipe to package it up before sending it to munki. I think this is also preferable for anyone who might want to create a JSS recipe or a .install recipe in the future.

I moved the code signature verification to the download recipe since that seems to be the generally accepted way of doing things and because it needs to be there when moving to having a pkg recipe.

The .app has proper version strings in the Info.plist so I got rid of the versioning stuff.

I also changed the spaces to tabs since half the file was tabbed and it's also the standard for plists.

Sample run:
```
$ autopkg run StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe -v
Processing StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe...
WARNING: StatPlus_mac_LE/StatPlus_mac_LE.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/downloads/statplusmacle.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename statplusmacle.zip
Unarchiver: Unarchived /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/downloads/statplusmacle.zip to /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE/StatPlus.app: valid on disk
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE/StatPlus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE/StatPlus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppPkgCreator
AppPkgCreator: Using path '/Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE/StatPlus.app' matched from globbed '/Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE/*.app'.
AppPkgCreator: Version: 6.2.6.1
AppPkgCreator: BundleID: com.analystsoft.mst.pro2
AppPkgCreator: Package already exists at path /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
FileFinder
FileFinder: Found file match: '/Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/StatPlus_mac_LE.pkg' from globbed '/Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/*.pkg'
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/StatPlus_mac_LE/StatPlus_mac_LE-6.2.6.1.plist
MunkiImporter: Copied pkg to /munki/pkgs/StatPlus_mac_LE/StatPlus_mac_LE-6.2.6.1.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.StatPlus_mac_LE/receipts/StatPlus_mac_LE.munki-receipt-20171020-114924.plist

The following new items were imported into Munki:
    Name             Version  Catalogs  Pkginfo Path                                   Pkg Repo Path                                
    ----             -------  --------  ------------                                   -------------                                
    StatPlus_mac_LE  6.2.6.1  testing   StatPlus_mac_LE/StatPlus_mac_LE-6.2.6.1.plist  StatPlus_mac_LE/StatPlus_mac_LE-6.2.6.1.pkg  
```