### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/DivergentMedia/EditReady.download.recipe
+++ b/DivergentMedia/EditReady.download.recipe
@@ -70,7 +70,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/EditReady.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.divergentmedia.EditReady" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S89CDJ6CWQ)</string>
 			</dict>

--- a/Lightworks/Lightworks.pkg.recipe
+++ b/Lightworks/Lightworks.pkg.recipe
@@ -37,9 +37,9 @@
       <key>Arguments</key>
       <dict>
         <key>source_path</key>
-        <string>%pathname%/%NAME%.app</string>
+        <string>%pathname%/Lightworks.app</string>
         <key>destination_path</key>
-        <string>%pkgroot%/Applications/%NAME%.app</string>
+        <string>%pkgroot%/Applications/Lightworks.app</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.