### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Erlang/ErlangURLProvider.py
+++ b/Erlang/ErlangURLProvider.py
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
 from __future__ import absolute_import
+
 import json
 import re
 

--- a/Erlang/ErlangURLProvider.py
+++ b/Erlang/ErlangURLProvider.py
@@ -89,7 +89,7 @@ class ErlangURLProvider(Processor):
         flavour = self.env.get('flavour', DEFAULT_FLAVOUR)
         get_version = self.env.get('version', DEFAULT_VERSION)
         response = urlopen(JSON_URL).read()
-        response = re.sub('\);', '', re.sub('^jsonCallback\(', '', response))
+        response = re.sub(r'\);', '', re.sub(r'^jsonCallback\(', '', response))
         erlang_tabs = json.loads(response)[u'tabs']
 
         # Use OS X information from json
@@ -108,7 +108,7 @@ class ErlangURLProvider(Processor):
             #
             while idx < len(filtered_packages):
                 url = DOWNLOAD_BASE_URL + filtered_packages[idx][u'path']
-                if re.match('.+\.dmg$', url):
+                if re.match(r'.+\.dmg$', url):
                     break
                 idx=idx+1
         else:

--- a/Erlang/ErlangURLProvider.py
+++ b/Erlang/ErlangURLProvider.py
@@ -23,6 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
+from __future__ import absolute_import
 import urllib2
 import json
 import re
@@ -87,7 +88,7 @@ class ErlangURLProvider(Processor):
         erlang_tabs = json.loads(response)[u'tabs']
 
         # Use OS X information from json
-        osx_tab = (tab for tab in erlang_tabs if tab[u'name'] == u'osx').next()
+        osx_tab = next((tab for tab in erlang_tabs if tab[u'name'] == u'osx'))
         # Select packages based on 'flavour'
         flavour_index = self.lookup_flavour(flavour)
         packages = osx_tab[u'flavours'][flavour_index][u'packages']

--- a/Erlang/ErlangURLProvider.py
+++ b/Erlang/ErlangURLProvider.py
@@ -24,11 +24,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
 from __future__ import absolute_import
-import urllib2
 import json
 import re
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = [u'ErlangURLProvider']
 
@@ -83,7 +87,7 @@ class ErlangURLProvider(Processor):
         target_os = self.env.get('target_os', DEFAULT_TARGET)
         flavour = self.env.get('flavour', DEFAULT_FLAVOUR)
         get_version = self.env.get('version', DEFAULT_VERSION)
-        response = urllib2.urlopen(JSON_URL).read()
+        response = urlopen(JSON_URL).read()
         response = re.sub('\);', '', re.sub('^jsonCallback\(', '', response))
         erlang_tabs = json.loads(response)[u'tabs']
 
@@ -100,7 +104,7 @@ class ErlangURLProvider(Processor):
             idx=0
             # Select the latest *DMG* as this is what the of the recipe
             # rest expects (and there are .tgz links around)
-            # 
+            #
             while idx < len(filtered_packages):
                 url = DOWNLOAD_BASE_URL + filtered_packages[idx][u'path']
                 if re.match('.+\.dmg$', url):
@@ -113,7 +117,7 @@ class ErlangURLProvider(Processor):
             except StopIteration:
                 raise ProcessorError('Specified package version %s could not be found for specified OS version %s'
                                       % (get_version, target_os))
-        
+
         version = re.match(r'.+erlang_(.+)~osx.+', url).group(1)
 
         self.env['url'] = url

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -14,8 +14,10 @@ and performing aklog
 """
 
 from __future__ import absolute_import
+
 import os
 import subprocess
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["AFSAuth"]

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 #
 # Copyright 2016 University of Oxford
 #

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -58,7 +58,7 @@ class AFSAuth(Processor):
 
         try:
             subprocess.call(["kinit", "-t", keytabname, principal])
-        except Exception as kiniterror:
+        except BaseException as kiniterror:
             raise ProcessorError('Problem running kinit %s' % kiniterror)
 
         aklog = self.env['aklog_path']
@@ -68,7 +68,7 @@ class AFSAuth(Processor):
         self.output('Calling aklog %s ...' % aklog, verbose_level=5)
         try:
             subprocess.call([aklog])
-        except Exception as aklogerror:
+        except BaseException as aklogerror:
             raise ProcessorError('Problem running aklog %s' % aklogerror)
 
     def main(self):

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -14,67 +14,68 @@ and performing aklog
 """
 
 from __future__ import absolute_import
-import os, subprocess
+import os
+import subprocess
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["AFSAuth"]
 
 class AFSAuth(Processor):
 
-	input_variables = {
-		'auth_method': {
-				 'description': 'keytab is the only option atm',
-				 'required': False,
-				 'default': 'keytab',
-				
-			       },
-		'aklog_path': {
-				 'description': 'Path to aklog binary',
-				 'required': False,
-				 'default': '/usr/local/bin/aklog',
-			       },
-	}
+    input_variables = {
+        'auth_method': {
+                 'description': 'keytab is the only option atm',
+                 'required': False,
+                 'default': 'keytab',
 
-	output_variables = {
-	              'test': {
-			         'description': 'for testing',
-				 'required': False,
+                   },
+        'aklog_path': {
+                 'description': 'Path to aklog binary',
+                 'required': False,
+                 'default': '/usr/local/bin/aklog',
+                   },
+    }
+
+    output_variables = {
+                  'test': {
+                     'description': 'for testing',
+                 'required': False,
                               },
         }
 
-	def gettoken(self):
+    def gettoken(self):
 
-		keytabname = os.environ.get("KEYTABNAME", None)
-		principal = os.environ.get("PRINCIPAL",None)
+        keytabname = os.environ.get("KEYTABNAME", None)
+        principal = os.environ.get("PRINCIPAL", None)
 
-                if keytabname is None:
-                    raise ProcessorError('Missing keytab environment variable')
+        if keytabname is None:
+            raise ProcessorError('Missing keytab environment variable')
 
-                self.output('Using Keytab %s with principal %s'
-                              % (keytabname, principal), verbose_level=3)
+        self.output('Using Keytab %s with principal %s'
+                    % (keytabname, principal), verbose_level=3)
 
-                self.output('Calling kinit ...', verbose_level=5)
+        self.output('Calling kinit ...', verbose_level=5)
 
-                try:
-		    subprocess.call(["kinit","-t",keytabname,principal])
-                except Exception as kiniterror:
-                    raise ProcessorError('Problem running kinit %s' % kiniterror)
+        try:
+            subprocess.call(["kinit", "-t", keytabname, principal])
+        except Exception as kiniterror:
+            raise ProcessorError('Problem running kinit %s' % kiniterror)
 
-                aklog = self.env['aklog_path']
-                if aklog is None:
-                    raise ProcessorError('Missing aklog_path setting')
+        aklog = self.env['aklog_path']
+        if aklog is None:
+            raise ProcessorError('Missing aklog_path setting')
 
-                self.output('Calling aklog %s ...' % aklog, verbose_level=5 )
-                try:
-		    subprocess.call([ aklog ])
-                except Exception as aklogerror:
-                    raise ProcessorError('Problem running aklog %s' % aklogerror)
-	
-	def main(self):
-		auth_method = self.env['auth_method']
-                if auth_method != 'keytab':
-                    raise ProcessorError('Unsupported authentication method: %s' % (auth_method) )
-		self.gettoken()
+        self.output('Calling aklog %s ...' % aklog, verbose_level=5)
+        try:
+            subprocess.call([aklog])
+        except Exception as aklogerror:
+            raise ProcessorError('Problem running aklog %s' % aklogerror)
+
+    def main(self):
+        auth_method = self.env['auth_method']
+        if auth_method != 'keytab':
+            raise ProcessorError('Unsupported authentication method: %s' % (auth_method))
+        self.gettoken()
 
 if __name__ == '__main__':
-	PROCESSOR = AFSAuth()
+    PROCESSOR = AFSAuth()

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -22,28 +22,25 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["AFSAuth"]
 
+
 class AFSAuth(Processor):
 
     input_variables = {
-        'auth_method': {
-                 'description': 'keytab is the only option atm',
-                 'required': False,
-                 'default': 'keytab',
-
-                   },
-        'aklog_path': {
-                 'description': 'Path to aklog binary',
-                 'required': False,
-                 'default': '/usr/local/bin/aklog',
-                   },
+        "auth_method": {
+            "description": "keytab is the only option atm",
+            "required": False,
+            "default": "keytab",
+        },
+        "aklog_path": {
+            "description": "Path to aklog binary",
+            "required": False,
+            "default": "/usr/local/bin/aklog",
+        },
     }
 
     output_variables = {
-                  'test': {
-                     'description': 'for testing',
-                 'required': False,
-                              },
-        }
+        "test": {"description": "for testing", "required": False,},
+    }
 
     def gettoken(self):
 
@@ -51,33 +48,38 @@ class AFSAuth(Processor):
         principal = os.environ.get("PRINCIPAL", None)
 
         if keytabname is None:
-            raise ProcessorError('Missing keytab environment variable')
+            raise ProcessorError("Missing keytab environment variable")
 
-        self.output('Using Keytab %s with principal %s'
-                    % (keytabname, principal), verbose_level=3)
+        self.output(
+            "Using Keytab %s with principal %s" % (keytabname, principal),
+            verbose_level=3,
+        )
 
-        self.output('Calling kinit ...', verbose_level=5)
+        self.output("Calling kinit ...", verbose_level=5)
 
         try:
             subprocess.call(["kinit", "-t", keytabname, principal])
         except Exception as kiniterror:
-            raise ProcessorError('Problem running kinit %s' % kiniterror)
+            raise ProcessorError("Problem running kinit %s" % kiniterror)
 
-        aklog = self.env['aklog_path']
+        aklog = self.env["aklog_path"]
         if aklog is None:
-            raise ProcessorError('Missing aklog_path setting')
+            raise ProcessorError("Missing aklog_path setting")
 
-        self.output('Calling aklog %s ...' % aklog, verbose_level=5)
+        self.output("Calling aklog %s ..." % aklog, verbose_level=5)
         try:
             subprocess.call([aklog])
         except Exception as aklogerror:
-            raise ProcessorError('Problem running aklog %s' % aklogerror)
+            raise ProcessorError("Problem running aklog %s" % aklogerror)
 
     def main(self):
-        auth_method = self.env['auth_method']
-        if auth_method != 'keytab':
-            raise ProcessorError('Unsupported authentication method: %s' % (auth_method))
+        auth_method = self.env["auth_method"]
+        if auth_method != "keytab":
+            raise ProcessorError(
+                "Unsupported authentication method: %s" % (auth_method)
+            )
         self.gettoken()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     PROCESSOR = AFSAuth()

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -60,7 +60,7 @@ class AFSAuth(Processor):
 
         try:
             subprocess.call(["kinit", "-t", keytabname, principal])
-        except BaseException as kiniterror:
+        except Exception as kiniterror:
             raise ProcessorError('Problem running kinit %s' % kiniterror)
 
         aklog = self.env['aklog_path']
@@ -70,7 +70,7 @@ class AFSAuth(Processor):
         self.output('Calling aklog %s ...' % aklog, verbose_level=5)
         try:
             subprocess.call([aklog])
-        except BaseException as aklogerror:
+        except Exception as aklogerror:
             raise ProcessorError('Problem running aklog %s' % aklogerror)
 
     def main(self):

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -13,6 +13,7 @@ Authorises AFS via shelling out and using a kerberos keytab
 and performing aklog
 """
 
+from __future__ import absolute_import
 import os, subprocess
 from autopkglib import Processor, ProcessorError
 

--- a/SharedProcessors/AFSDeauth.py
+++ b/SharedProcessors/AFSDeauth.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 #
 # Copyright 2016 University of Oxford
 #

--- a/SharedProcessors/AFSDeauth.py
+++ b/SharedProcessors/AFSDeauth.py
@@ -18,27 +18,27 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["AFSDeauth"]
 
 class AFSDeauth(Processor):
-	
-	input_variables = {
-		'auth_method': {
-				 'description': 'keytab is the only option at the moment',
-				 'required': False,
-			       },
-	}
 
-	output_variables = {
+    input_variables = {
+        'auth_method': {
+                 'description': 'keytab is the only option at the moment',
+                 'required': False,
+                   },
+    }
+
+    output_variables = {
                        'test': {
-				 'description': 'used for testing',
-				 'required': False,
+                 'description': 'used for testing',
+                 'required': False,
                                },
         }
 
-	def killtoken(self):
-		subprocess.call(["unlog"], shell=True)
-		subprocess.call(["kdestroy"], shell=True)
-	
-	def main(self):
-		self.killtoken()
+    def killtoken(self):
+        subprocess.call(["unlog"], shell=True)
+        subprocess.call(["kdestroy"], shell=True)
+
+    def main(self):
+        self.killtoken()
 
 if __name__ == '__main__':
-	PROCESSOR = AFSDeauth()
+    PROCESSOR = AFSDeauth()

--- a/SharedProcessors/AFSDeauth.py
+++ b/SharedProcessors/AFSDeauth.py
@@ -11,6 +11,7 @@
 De-authenticates AFS via unlog and kdestroy
 """
 
+from __future__ import absolute_import
 import subprocess
 from autopkglib import Processor, ProcessorError
 

--- a/SharedProcessors/AFSDeauth.py
+++ b/SharedProcessors/AFSDeauth.py
@@ -19,21 +19,19 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["AFSDeauth"]
 
+
 class AFSDeauth(Processor):
 
     input_variables = {
-        'auth_method': {
-                 'description': 'keytab is the only option at the moment',
-                 'required': False,
-                   },
+        "auth_method": {
+            "description": "keytab is the only option at the moment",
+            "required": False,
+        },
     }
 
     output_variables = {
-                       'test': {
-                 'description': 'used for testing',
-                 'required': False,
-                               },
-        }
+        "test": {"description": "used for testing", "required": False,},
+    }
 
     def killtoken(self):
         subprocess.call(["unlog"], shell=True)
@@ -42,5 +40,6 @@ class AFSDeauth(Processor):
     def main(self):
         self.killtoken()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     PROCESSOR = AFSDeauth()

--- a/SharedProcessors/AFSDeauth.py
+++ b/SharedProcessors/AFSDeauth.py
@@ -34,8 +34,8 @@ class AFSDeauth(Processor):
     }
 
     def killtoken(self):
-        subprocess.call(["unlog"], shell=True)
-        subprocess.call(["kdestroy"], shell=True)
+        subprocess.call(["unlog"])
+        subprocess.call(["/usr/bin/kdestroy"])
 
     def main(self):
         self.killtoken()

--- a/SharedProcessors/AFSDeauth.py
+++ b/SharedProcessors/AFSDeauth.py
@@ -12,7 +12,9 @@ De-authenticates AFS via unlog and kdestroy
 """
 
 from __future__ import absolute_import
+
 import subprocess
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["AFSDeauth"]

--- a/SharedProcessors/FSFileProvider.py
+++ b/SharedProcessors/FSFileProvider.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #

--- a/SharedProcessors/FSFileProvider.py
+++ b/SharedProcessors/FSFileProvider.py
@@ -13,6 +13,7 @@ list files in the specified path, performs regex and Version checking
 The highest version is returned as file
 """
 
+from __future__ import absolute_import
 import re, os
 from distutils.version import LooseVersion
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/FSFileProvider.py
+++ b/SharedProcessors/FSFileProvider.py
@@ -42,7 +42,7 @@ class FSFileProvider(Processor):
             'result_output_var_name': {
                 'description': 'desc',
                 },
-            }	
+            }
 
     def get_path_and_search(self, path, re_pattern):
         match_pattern = re.compile(re_pattern)

--- a/SharedProcessors/FSFileProvider.py
+++ b/SharedProcessors/FSFileProvider.py
@@ -23,36 +23,33 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["FSFileProvider"]
 
+
 class FSFileProvider(Processor):
     input_variables = {
-            're_pattern': {
-                'description': 'Regular expression (Python) to match against.',
-                'required': True,
-
-                },
-            'path': {
-                'description': 'provide the afs path',
-                'required': True,
-                },
-            'result_output_var_name': {
-                'description': 'desc',
-                'required': False,
-                'default': 'match',
-                },
-            }
+        "re_pattern": {
+            "description": "Regular expression (Python) to match against.",
+            "required": True,
+        },
+        "path": {"description": "provide the afs path", "required": True,},
+        "result_output_var_name": {
+            "description": "desc",
+            "required": False,
+            "default": "match",
+        },
+    }
 
     output_variables = {
-            'result_output_var_name': {
-                'description': 'desc',
-                },
-            }
+        "result_output_var_name": {"description": "desc",},
+    }
 
     def get_path_and_search(self, path, re_pattern):
         match_pattern = re.compile(re_pattern)
         try:
             software = os.listdir(path)
         except OSError:
-            raise ProcessorError('Error Messages will get better with time'(path, re_pattern))
+            raise ProcessorError(
+                "Error Messages will get better with time"(path, re_pattern)
+            )
         highestver = ""
         finalmatch = None
         for x in software:
@@ -64,17 +61,20 @@ class FSFileProvider(Processor):
         if finalmatch:
             return (finalmatch.group(finalmatch.lastindex or 0), finalmatch.groupdict())
         else:
-            raise ProcessorError('The regular expression \'%s\' does not match any file in path \'%s\'' % (re_pattern, path))
+            raise ProcessorError(
+                "The regular expression '%s' does not match any file in path '%s'"
+                % (re_pattern, path)
+            )
 
     def main(self):
-        output_var_name = self.env['result_output_var_name']
+        output_var_name = self.env["result_output_var_name"]
 
-        if 'path' in self.env:
-            path = self.env['path']
-        if 're_pattern' in self.env:
-            re_pattern = self.env['re_pattern']
+        if "path" in self.env:
+            path = self.env["path"]
+        if "re_pattern" in self.env:
+            re_pattern = self.env["re_pattern"]
 
-        groupmatch, groupdict = self.get_path_and_search(path,re_pattern)
+        groupmatch, groupdict = self.get_path_and_search(path, re_pattern)
 
         if output_var_name not in groupdict.keys():
             groupdict[output_var_name] = groupmatch
@@ -82,9 +82,11 @@ class FSFileProvider(Processor):
         self.output_variables = {}
         for key in groupdict.keys():
             self.env[key] = groupdict[key]
-            self.output('Found matching text (%s): %s' % (key, self.env[key], ))
+            self.output("Found matching text (%s): %s" % (key, self.env[key],))
             self.output_variables[key] = {
-                    'description': 'Matched regular expression group'}
+                "description": "Matched regular expression group"
+            }
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     PROCESSOR = FSFileProvider()

--- a/SharedProcessors/FSFileProvider.py
+++ b/SharedProcessors/FSFileProvider.py
@@ -14,8 +14,11 @@ The highest version is returned as file
 """
 
 from __future__ import absolute_import
-import re, os
+
+import os
+import re
 from distutils.version import LooseVersion
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["FSFileProvider"]


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including the `next()` method in ErlangURLProvider), but this should catch the low-hanging fruit right now.