### PR TITLE
Simplify TimeOut recipes and add code signature verification

### DIFF
--- a/TimeOut/TimeOut.download.recipe
+++ b/TimeOut/TimeOut.download.recipe
@@ -3,76 +3,40 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Time Out</string>
+    <string>Downloads the current release version of Time Out (formerly known as Simon).</string>
     <key>Identifier</key>
     <string>uk.ac.ox.orchard.download.TimeOut</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>TimeOut</string>
-        <key>BASE_URL</key>
-        <string>http://www.dejal.com</string>
-        <key>HOMEPAGE_URL</key>
-        <string>%BASE_URL%/apps/</string>
-        <key>DOWNLOAD_URL</key>
-        <string>%BASE_URL%/download</string>
-	<key>USER_AGENT</key>
-	<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/601.4.4 (KHTML, like Gecko) Version/9.0.3 Safari/601.4.4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.0.0</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
-            <key>Arguments</key> 
+            <key>Arguments</key>
             <dict>
-              <key>url</key>
-              <string>%HOMEPAGE_URL%</string>
-              <key>result_output_var_name</key>
-              <string>DOWNLOADPAGE_URL</string>
-              <key>re_pattern</key>
-              <string>.*href=&quot;\/(download\/\?prod=timeout.*)&quot; title.*</string>
-	      <key>request_headers</key>
-	      <dict>
-	      	<key>user-agent</key>
-		<string>%USER_AGENT%</string>
-	      </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key> 
-            <dict>
-              <key>url</key>
-              <string>%BASE_URL%/%DOWNLOADPAGE_URL%</string>
-              <key>result_output_var_name</key>
-              <string>FILENAME</string>
-              <key>re_pattern</key>
-              <string>http-equiv=&quot;refresh&quot;.*url=(.*zip)&quot;</string>
-	      <key>request_headers</key>
-	      <dict>
-	      	<key>user-agent</key>
-		<string>%USER_AGENT%</string>
-	      </dict>
+                <key>re_pattern</key>
+                <string>&lt;span class="version"&gt;version ([\d\.]+)&lt;/span&gt;</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
+                <key>url</key>
+                <string>http://www.dejal.com/apps/</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
-            <key>Arguments</key> 
+            <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
-		<key>request_headers</key>
-		<dict>
-		  <key>user-agent</key>
-		  <string>%USER_AGENT%</string>
-		</dict>
+                <string>%NAME%-%version%.zip</string>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%/%FILENAME%</string>
+                <string>http://www.dejal.com/download/?prod=timeout&amp;vers=%version%&amp;rel=gen&amp;lang=en&amp;op=get&amp;ref=apps</string>
             </dict>
         </dict>
         <dict>
@@ -87,9 +51,31 @@
                 <key>archive_path</key>
                 <string>%pathname%</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
                 <key>purge_destination</key>
                 <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Time Out.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.dejal.timeout" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6Z7QW53WB6")</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Time Out.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
             </dict>
         </dict>
     </array>

--- a/TimeOut/TimeOut.munki.recipe
+++ b/TimeOut/TimeOut.munki.recipe
@@ -3,25 +3,29 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Time Out and imports into Munki.</string>
+    <string>Downloads the current release version of Time Out (formerly known as Simon) and imports into Munki.</string>
     <key>Identifier</key>
     <string>uk.ac.ox.orchard.munki.TimeOut</string>
     <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>Time_Out</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>%NAME%</string>
+        <key>NAME</key>
+        <string>TimeOut</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Time Out.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
             </array>
-            <key>category</key>
-            <string>Office and Productivity</string>
             <key>description</key>
-            <string>Time Out is a break reminder tool with micro-breaks</string>
+            <string>Monitor changes and crashes with Web sites and servers.</string>
+            <key>developer</key>
+            <string>Dejal Systems</string>
             <key>display_name</key>
             <string>Time Out</string>
             <key>name</key>
@@ -31,21 +35,34 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.0</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>uk.ac.ox.orchard.pkg.TimeOut</string>
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
             </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
         </dict>
     </array>
 </dict>

--- a/TimeOut/TimeOut.munki.recipe
+++ b/TimeOut/TimeOut.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>uk.ac.ox.orchard.pkg.TimeOut</string>
+    <string>uk.ac.ox.orchard.download.TimeOut</string>
     <key>Process</key>
     <array>
         <dict>

--- a/TimeOut/TimeOut.pkg.recipe
+++ b/TimeOut/TimeOut.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Time Out and builds a package.</string>
+    <string>Downloads the current release version of Time Out (formerly known as Simon) and creates a package.</string>
     <key>Identifier</key>
     <string>uk.ac.ox.orchard.pkg.TimeOut</string>
     <key>Input</key>
@@ -11,50 +11,12 @@
         <key>NAME</key>
         <string>TimeOut</string>
     </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>uk.ac.ox.orchard.download.TimeOut</string>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/Time Out.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>PkgCreator</string>
@@ -62,25 +24,27 @@
             <dict>
                 <key>pkg_request</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>id</key>
-                    <string>ch.sudo.TimeOut</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>
+                            <key>group</key>
+                            <string>admin</string>
                             <key>path</key>
                             <string>Applications</string>
                             <key>user</key>
                             <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
                         </dict>
                     </array>
+                    <key>id</key>
+                    <string>com.dejal.timeout</string>
+                    <key>options</key>
+                    <string>purge_ds_store</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
+                    <key>pkgroot</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
         </dict>


### PR DESCRIPTION
This PR simplifies the process of downloading TimeOut, adds code signature verification, and streamlines a few aspects of the package creation process.

I'm deprecating my Simon recipes since the product has transitioned to TimeOut, and I'll be pointing people who use my recipes to this repo instead.