### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/AntConc/AntConc.download.recipe
+++ b/AntConc/AntConc.download.recipe
@@ -31,7 +31,7 @@
     <key>SEARCH_PATTERN</key>
     <string><![CDATA[(?P<download_url>/software/antconc/releases/AntConc.*/AntConc\.zip).*\((?P<version>.*)\)]]></string>
   </dict>
-  <key>MiniumumVersion</key>
+  <key>MinimumVersion</key>
   <string>1.0</string>
   <key>Process</key>
   <array>
@@ -89,5 +89,3 @@
   </array>     
 </dict>
 </plist>    
-
-


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.