### PR TITLE
Adding Installs Array to Creative Cloud Desktop App Recipe

### DIFF
--- a/Adobe/AdobeCreativeCloudInstaller.munki.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller.munki.recipe
@@ -58,7 +58,26 @@
     <array>
       <dict>
         <key>Arguments</key>
-        <dict/>
+        <dict>
+          <key>additional_pkginfo</key>
+          <dict>
+            <key>installs</key>
+            <array>
+              <dict>
+                <key>CFBundleName</key>
+                <string>Creative Cloud</string>
+                <key>CFBundleShortVersionString</key>
+                <string>%version%</string>
+                <key>path</key>
+                <string>/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app</string>
+                <key>type</key>
+                <string>application</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+              </dict>
+            </array>
+          </dict>
+        </dict>
         <key>Processor</key>
         <string>MunkiPkginfoMerger</string>
       </dict>

--- a/Adobe/AdobeCreativeCloudInstaller.munki.recipe
+++ b/Adobe/AdobeCreativeCloudInstaller.munki.recipe
@@ -58,19 +58,6 @@
     <array>
       <dict>
         <key>Arguments</key>
-        <dict>
-          <key>installs_item_paths</key>
-          <array>
-            <string>/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app</string>
-          </array>
-          <key>version_comparison_key</key>
-          <string>CFBundleShortVersionString</string>
-        </dict>
-        <key>Processor</key>
-        <string>MunkiInstallsItemsCreator</string>
-      </dict>
-      <dict>
-        <key>Arguments</key>
         <dict/>
         <key>Processor</key>
         <string>MunkiPkginfoMerger</string>


### PR DESCRIPTION
Adding an installs array to the CCDA recipe so that Munki can properly tell whether the update is needed or if the built-in CCDA updater has gotten there first.