### PR TITLE
Use GitHubReleasesInfoProvider for Protege download

### DIFF
--- a/Protege/Protege.download.recipe
+++ b/Protege/Protege.download.recipe
@@ -19,7 +19,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of Protégé</string>
 	<key>Identifier</key>
-	<string>uk.ac.ox.orchard.download.Protege-eshirk</string>
+	<string>uk.ac.ox.orchard.download.Protege</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/Protege/Protege.download.recipe
+++ b/Protege/Protege.download.recipe
@@ -20,41 +20,38 @@
   <string>Downloads the current release version of Protégé</string>
   <key>Identifier</key>
   <string>uk.ac.ox.orchard.download.Protege</string>
-  <key>Input</key>
-  <dict>
-    <key>NAME</key>
-    <string>Protege</string>
-    <key>BASE_URL</key>
-    <string>https://github.com</string>
-    <key>DOWNLOAD_URL</key>
-    <string>%BASE_URL%/protegeproject/protege-distribution/releases</string>
-    <key>SEARCH_PATTERN</key>
-    <string>"([^"]+-(?P&lt;version&gt;[0-9.]+)-os-x.zip)"</string>
-  </dict>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>MunkiAdmin</string>
+		<key>GITHUB_REPO</key>
+		<string>protegeproject/protege-distribution</string>
+		<key>ASSET_REGEX</key>
+		<string>Protege-.*-os-x.zip</string>
+		<key>INCLUDE_PRERELEASES</key>
+		<string></string>
+	</dict>
   <key>MinimumVersion</key>
   <string>0.2.9</string>
   <key>Process</key>
   <array>
     <dict>
       <key>Processor</key>
-      <string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
       <key>Arguments</key>
       <dict>
-        <key>url</key>
-        <string>%DOWNLOAD_URL%</string>
-        <key>re_pattern</key>
-        <string>%SEARCH_PATTERN%</string>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+				<key>include_prereleases</key>
+				<string>%INCLUDE_PRERELEASES%</string>
       </dict>
     </dict>
-    <dict>
-      <key>Processor</key>
-      <string>URLDownloader</string>
-      <key>Arguments</key>
-      <dict>
-        <key>url</key>
-        <string>%BASE_URL%/%match%</string>
-      </dict>
-    </dict>
+   	<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
     <dict>
       <key>Processor</key>
       <string>EndOfCheckPhase</string>

--- a/Protege/Protege.download.recipe
+++ b/Protege/Protege.download.recipe
@@ -7,30 +7,30 @@
 		<key>Copyright</key>
 		<string>University of Oxford 2016</string>
 		<key>Author</key>
-			<dict>
-				<key>Name</key>
-				<string>Ian Collier</string>
-				<key>Email</key>
-				<string>ian.collier at cs.ox.ac.uk</string>
-				<key>Github</key>
-				<string>imc0</string>
-			</dict>
+		<dict>
+			<key>Name</key>
+			<string>Ian Collier</string>
+			<key>Email</key>
+			<string>ian.collier at cs.ox.ac.uk</string>
+			<key>Github</key>
+			<string>imc0</string>
+		</dict>
 	</dict>
 	<key>Description</key>
 	<string>Downloads the current release version of Protégé</string>
 	<key>Identifier</key>
 	<string>uk.ac.ox.orchard.download.Protege-eshirk</string>
 	<key>Input</key>
-		<dict>
-			<key>NAME</key>
-			<string>MunkiAdmin</string>
-			<key>GITHUB_REPO</key>
-			<string>protegeproject/protege-distribution</string>
-			<key>ASSET_REGEX</key>
-			<string>Protege-.*-os-x.zip</string>
-			<key>INCLUDE_PRERELEASES</key>
-			<string></string>
-		</dict>
+	<dict>
+		<key>NAME</key>
+		<string>MunkiAdmin</string>
+		<key>GITHUB_REPO</key>
+		<string>protegeproject/protege-distribution</string>
+		<key>ASSET_REGEX</key>
+		<string>Protege-.*-os-x.zip</string>
+		<key>INCLUDE_PRERELEASES</key>
+		<string></string>
+	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
 	<key>Process</key>
@@ -39,14 +39,14 @@
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>
 			<key>Arguments</key>
-				<dict>
-					<key>asset_regex</key>
-					<string>%ASSET_REGEX%</string>
-					<key>github_repo</key>
-					<string>%GITHUB_REPO%</string>
-					<key>include_prereleases</key>
-					<string>%INCLUDE_PRERELEASES%</string>
-				</dict>
+			<dict>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+				<key>include_prereleases</key>
+				<string>%INCLUDE_PRERELEASES%</string>
+			</dict>
 			</dict>
 		<dict>
 			<key>Processor</key>

--- a/Protege/Protege.download.recipe
+++ b/Protege/Protege.download.recipe
@@ -2,60 +2,60 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Attribution</key>
-  <dict>
-    <key>Copyright</key>
-    <string>University of Oxford 2016</string>
-    <key>Author</key>
-    <dict>
-      <key>Name</key>
-      <string>Ian Collier</string>
-      <key>Email</key>
-      <string>ian.collier at cs.ox.ac.uk</string>
-      <key>Github</key>
-      <string>imc0</string>
-    </dict>
-  </dict>
-  <key>Description</key>
-  <string>Downloads the current release version of Protégé</string>
-  <key>Identifier</key>
-  <string>uk.ac.ox.orchard.download.Protege</string>
-	<key>Input</key>
+	<key>Attribution</key>
 	<dict>
-		<key>NAME</key>
-		<string>MunkiAdmin</string>
-		<key>GITHUB_REPO</key>
-		<string>protegeproject/protege-distribution</string>
-		<key>ASSET_REGEX</key>
-		<string>Protege-.*-os-x.zip</string>
-		<key>INCLUDE_PRERELEASES</key>
-		<string></string>
+		<key>Copyright</key>
+		<string>University of Oxford 2016</string>
+		<key>Author</key>
+			<dict>
+				<key>Name</key>
+				<string>Ian Collier</string>
+				<key>Email</key>
+				<string>ian.collier at cs.ox.ac.uk</string>
+				<key>Github</key>
+				<string>imc0</string>
+			</dict>
 	</dict>
-  <key>MinimumVersion</key>
-  <string>0.2.9</string>
-  <key>Process</key>
-  <array>
-    <dict>
-      <key>Processor</key>
+	<key>Description</key>
+	<string>Downloads the current release version of Protégé</string>
+	<key>Identifier</key>
+	<string>uk.ac.ox.orchard.download.Protege-eshirk</string>
+	<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>MunkiAdmin</string>
+			<key>GITHUB_REPO</key>
+			<string>protegeproject/protege-distribution</string>
+			<key>ASSET_REGEX</key>
+			<string>Protege-.*-os-x.zip</string>
+			<key>INCLUDE_PRERELEASES</key>
+			<string></string>
+		</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>
-      <key>Arguments</key>
-      <dict>
-				<key>asset_regex</key>
-				<string>%ASSET_REGEX%</string>
-				<key>github_repo</key>
-				<string>%GITHUB_REPO%</string>
-				<key>include_prereleases</key>
-				<string>%INCLUDE_PRERELEASES%</string>
-      </dict>
-    </dict>
-   	<dict>
+			<key>Arguments</key>
+				<dict>
+					<key>asset_regex</key>
+					<string>%ASSET_REGEX%</string>
+					<key>github_repo</key>
+					<string>%GITHUB_REPO%</string>
+					<key>include_prereleases</key>
+					<string>%INCLUDE_PRERELEASES%</string>
+				</dict>
+			</dict>
+		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
-    <dict>
-      <key>Processor</key>
-      <string>EndOfCheckPhase</string>
-    </dict>
-  </array>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The new GitHub html template for releases broke the Protege download recipe; this PR looks like it'll fix it. Tail end of output from test run:

The following new items were downloaded:
Download Path                                                                        
 -------------                                                                        
 /Users/Shared/AutoPkg/Cache/local.download.Protege/downloads/Protege-5.5.0-os-x.zip