### PR TITLE
Update oXygenXMLEditor.munki.recipe

### DIFF
--- a/oXygenXMLEditor/oXygenXMLEditor.munki.recipe
+++ b/oXygenXMLEditor/oXygenXMLEditor.munki.recipe
@@ -17,11 +17,13 @@
       </dict>
     </dict>
     <key>Description</key>
-    <string></string>
+    <string>Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>uk.ac.ox.orchard.munki.oXygenXMLEditor</string>
     <key>Input</key>
     <dict>
+      <key>DERIVE_MIN_OS</key>
+      <string>YES</string>
       <key>MUNKI_REPO_SUBDIR</key>
       <string>%NAME%</string>
       <key>NAME</key>
@@ -58,11 +60,30 @@ exit 0
       </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>uk.ac.ox.orchard.pkg.oXygenXMLEditor</string>
     <key>Process</key>
     <array>
+      <dict>
+        <key>Arguments</key>
+        <dict>
+            <key>faux_root</key>
+            <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+            <key>installs_item_paths</key>
+            <array>
+                <string>/Applications/Oxygen/Oxygen XML Editor.app</string>
+            </array>
+            <key>derive_minimum_os_version</key>
+            <string>%DERIVE_MIN_OS%</string>
+        </dict>
+        <key>Processor</key>
+        <string>MunkiInstallsItemsCreator</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
+        <string>MunkiPkginfoMerger</string>
+      </dict>
       <dict>
         <key>Processor</key>
         <string>MunkiImporter</string>


### PR DESCRIPTION
Hi, 

The  Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in MunkiInstallsItemsCreator to create an installs array for Oxygen XML Editor.app with support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.11

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/orchard-recipes/oXygenXMLEditor/oXygenXMLEditor.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/orchard-recipes/oXygenXMLEditor/oXygenXMLEditor.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/orchard-recipes/oXygenXMLEditor/oXygenXMLEditor.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 25.0
URLTextSearcher: Found matching text (urlpath): /InstData/Editor/MacOSX/VM/oxygen-openjdk.dmg
URLTextSearcher: Found matching text (match): /InstData/Editor/MacOSX/VM/oxygen-openjdk.dmg
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/downloads/Oxygen_XML_Editor-25.0.dmg
EndOfCheckPhase
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/pkgroot
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/pkgroot/Applications
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/downloads/Oxygen_XML_Editor-25.0.dmg
Copier: Copied /private/tmp/dmg.h9cAnK/Oxygen XML Editor to /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/pkgroot/Applications/Oxygen
PkgCreator
PkgCreator: Package already exists at path /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/Oxygen_XML_Editor-25.0.pkg.
PkgCreator: Existing package matches version and identifier, not building.
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Oxygen/Oxygen XML Editor.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.11
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'ro.sync.exml.Oxygen', 'CFBundleName': 'Oxygen XML Editor', 'CFBundleShortVersionString': '25.0', 'CFBundleVersion': '25.0', 'minosversion': '10.11', 'path': '/Applications/Oxygen/Oxygen XML Editor.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.11'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/Oxygen_XML_Editor/Oxygen_XML_Editor-25.0__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/Oxygen_XML_Editor/Oxygen_XML_Editor-25.0__2.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/uk.ac.ox.orchard.munki.oXygenXMLEditor/receipts/oXygenXMLEditor.munki-receipt-20230307-171052.plist

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                       Pkg Repo Path                                    Icon Repo Path  
    ----               -------  --------  ------------                                       -------------                                    --------------  
    Oxygen_XML_Editor  25.0     testing   Oxygen_XML_Editor/Oxygen_XML_Editor-25.0__2.plist  Oxygen_XML_Editor/Oxygen_XML_Editor-25.0__2.pkg 
```