### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Eclipse/EclipseMars.download.recipe
+++ b/Eclipse/EclipseMars.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Eclipse_Mars</string>
         <key>url</key>
-        <string>http://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-macosx-cocoa-x86_64.tar.gz</string>
+        <string>https://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-macosx-cocoa-x86_64.tar.gz</string>
     </dict>
     <key>Process</key>
     <array>

--- a/GanttProject/GanttProject.download.recipe
+++ b/GanttProject/GanttProject.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>GanttProject</string>
         <key>BASE_URL</key>
-        <string>http://www.ganttproject.biz</string>
+        <string>https://www.ganttproject.biz</string>
         <key>SEARCH_URL</key>
         <string>%BASE_URL%/download/free</string>
         <key>SEARCH_URL_COOKIE</key>

--- a/mtr/mtr.download.recipe
+++ b/mtr/mtr.download.recipe
@@ -25,7 +25,7 @@
     <key>NAME</key>
     <string>mtr</string>
     <key>BASE_URL</key>
-    <string>http://rudix.org</string>
+    <string>https://rudix.org</string>
     <key>SEARCH_URL</key>
     <string>%BASE_URL%/packages/mtr.html</string>
     <key>OSX_VER</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!