### PR TITLE
Fix version missing from Google Cloud SDK download URLs

### DIFF
--- a/Google_Cloud_SDK/Google_Cloud_SDK.download.recipe
+++ b/Google_Cloud_SDK/Google_Cloud_SDK.download.recipe
@@ -26,8 +26,10 @@
     <string>Google_Cloud_SDK</string>
     <key>BASE_URL</key>
     <string>https://cloud.google.com/sdk/docs/quickstart-macos</string>
-    <key>SEARCH_PATTERN</key>
-    <string>href="(?P&lt;pkgurl&gt;http[^"]+-(?P&lt;version&gt;[0-9.]+)-darwin-x86_64.tar.gz)"</string>
+    <key>PKG_SEARCH_PATTERN</key>
+    <string>href="(?P&lt;pkgurl&gt;http[^"]+-darwin-x86_64.tar.gz)"</string>
+    <key>VERSION_SEARCH_PATTERN</key>
+    <string>&lt;h2[^\&gt;]+version\s\((?P&lt;version&gt;[0-9\.]{2,})\)</string>
   </dict>
   <key>Process</key>
   <array>
@@ -39,7 +41,18 @@
         <key>url</key>
         <string>%BASE_URL%</string>
         <key>re_pattern</key>
-        <string>%SEARCH_PATTERN%</string>
+        <string>%VERSION_SEARCH_PATTERN%</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>URLTextSearcher</string>
+      <key>Arguments</key>
+      <dict>
+        <key>url</key>
+        <string>%BASE_URL%</string>
+        <key>re_pattern</key>
+        <string>%PKG_SEARCH_PATTERN%</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
Google seems to have updated the download links for the Google Cloud SDK. 
This PR:
- Adds a new regex pattern to try and lift the version out of the download page. This match is stored as the `version` variable.
- Adds a new `URLTextSearcher` step to find the version on the page, _before_ searching for the download URL of the package.
- Updates the regex pattern of the download regex to remove the version reference, matching what is now on the download page.