### PR TITLE
Deprecate Reflector 2 recipes

### DIFF
--- a/Reflector2/Reflector2.download.recipe
+++ b/Reflector2/Reflector2.download.recipe
@@ -28,9 +28,18 @@
     <string>(?P&lt;url&gt;http://download.airsquirrels.com/Reflector2/Mac/Reflector-(?P&lt;version&gt;.+).dmg)</string>
   </dict>
   <key>MinimumVersion</key>
-  <string>0.5.0</string>
+  <string>1.1</string>
   <key>Process</key>
   <array>
+    <dict>
+        <key>Processor</key>
+        <string>DeprecationWarning</string>
+        <key>Arguments</key>
+        <dict>
+            <key>warning_message</key>
+            <string>Consider switching to the Reflector 4 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+        </dict>
+    </dict>
     <dict>
       <key>Processor</key>
       <string>URLTextSearcher</string>


### PR DESCRIPTION
Reflector 4 is the latest version. This PR deprecates the Reflector 2 recipes in this repo, and points users to an alternative Reflector 4 recipe in the dataJAR-recipes repo.