### PR TITLE
Deprecate Mono recipes

### DIFF
--- a/Mono/Mono.download.recipe
+++ b/Mono/Mono.download.recipe
@@ -40,9 +40,18 @@
     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12</string>
   </dict>
   <key>MinimumVersion</key>
-  <string>0.4.0</string>
+  <string>1.1</string>
   <key>Process</key>
   <array>
+    <dict>
+      <key>Processor</key>
+      <string>DeprecationWarning</string>
+      <key>Arguments</key>
+      <dict>
+        <key>warning_message</key>
+        <string>The Mono Project's final patch release was in February 2024 (details: https://www.mono-project.com/). This recipe is deprecated and will be removed in the future.</string>
+      </dict>
+    </dict>
     <dict>
       <key>Processor</key>
       <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates Mono Project recipes, since the last major release was in 2019 and the last minor patch was in February 2024 ([details](https://www.mono-project.com/)).