### PR TITLE
Fix Lightworks recipes

### DIFF
--- a/Lightworks/Lightworks.download.recipe
+++ b/Lightworks/Lightworks.download.recipe
@@ -2,45 +2,45 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the current release version of EditShare Lightworks</string>
-	<key>Identifier</key>
-	<string>uk.ac.ox.orchard.download.lightworks</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Lightworks</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.4.2</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>https://25893642.fs1.hubspotusercontent-eu1.net/hubfs/25893642/Lightworks%20Latest%20Version/lightworks_mac.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/Lightworks.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.LWKS.lightworks" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7SP64L7NC9")</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-	</array>
+    <key>Description</key>
+    <string>Downloads the current release version of EditShare Lightworks</string>
+    <key>Identifier</key>
+    <string>uk.ac.ox.orchard.download.lightworks</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Lightworks</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://25893642.fs1.hubspotusercontent-eu1.net/hubfs/25893642/Lightworks%20Latest%20Version/lightworks_mac.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Lightworks.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.LWKS.lightworks" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7SP64L7NC9")</string>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/Lightworks/Lightworks.download.recipe
+++ b/Lightworks/Lightworks.download.recipe
@@ -2,63 +2,45 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the current release version of EditShare Lightworks</string>
-    <key>Identifier</key>
-    <string>uk.ac.ox.orchard.download.lightworks</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>Lightworks</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.4.2</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-               <key>url</key>
-               <string><![CDATA[https://www.lwks.com/index.php?option=com_lwks&view=download&Itemid=206]]></string>
-               <key>re_pattern</key>
-               <string><![CDATA[Lightworks for Mac OS X</h.*<strong>Latest release:</strong>.*<strong>(.*)</strong>.*<span>Release date:</span>]]></string>
-               <key>result_output_var_name</key>
-               <string>version</string>
-               <key>re_flags</key>
-               <array>
-                   <string>MULTILINE</string>
-                   <string>DOTALL</string>
-               </array>
-        </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string><![CDATA[https://www.lwks.com/index.php?option=com_docman&task=doc_download&gid=210]]></string>
-                <key>filename</key>
-                <string>lightworks-download-%version%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%/Lightworks.app</string>
-                <key>requirement</key>
-                <string>anchor apple generic and identifier "com.LWKS.lightworks" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7SP64L7NC9")</string>
-            </dict>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Downloads the current release version of EditShare Lightworks</string>
+	<key>Identifier</key>
+	<string>uk.ac.ox.orchard.download.lightworks</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Lightworks</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.2</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>https://25893642.fs1.hubspotusercontent-eu1.net/hubfs/25893642/Lightworks%20Latest%20Version/lightworks_mac.dmg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Lightworks.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.LWKS.lightworks" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7SP64L7NC9")</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the Lightworks recipe with a new download URL and aligns plist syntax to AutoPkg conventions.

Verbose recipe run output:

```
% autopkg run -vvq 'Lightworks/Lightworks.download.recipe'
Processing Lightworks/Lightworks.download.recipe...
WARNING: Lightworks/Lightworks.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Lightworks.dmg',
           'url': 'https://25893642.fs1.hubspotusercontent-eu1.net/hubfs/25893642/Lightworks%20Latest%20Version/lightworks_mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 18 Dec 2024 16:04:36 GMT
URLDownloader: Storing new ETag header: "b8fe8813db23688ac6da7f8705f82bde"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/downloads/Lightworks.dmg
{'Output': {'download_changed': True,
            'etag': '"b8fe8813db23688ac6da7f8705f82bde"',
            'last_modified': 'Wed, 18 Dec 2024 16:04:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/downloads/Lightworks.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/downloads/Lightworks.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/downloads/Lightworks.dmg/Lightworks.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.LWKS.lightworks" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7SP64L7NC9")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/downloads/Lightworks.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ovsNm3/Lightworks.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ovsNm3/Lightworks.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ovsNm3/Lightworks.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/receipts/Lightworks.download-receipt-20241228-223745.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.lightworks/downloads/Lightworks.dmg
```
