### PR TITLE
Deprecate HaskellPlatform recipes

### DIFF
--- a/HaskellPlatform/HaskellPlatform.download.recipe
+++ b/HaskellPlatform/HaskellPlatform.download.recipe
@@ -24,6 +24,15 @@
   <array>
     <dict>
       <key>Processor</key>
+      <string>DeprecationWarning</string>
+      <key>Arguments</key>
+      <dict>
+        <key>warning_message</key>
+        <string>The Haskell Platform was deprecated in 2022. This recipe will be removed in the future.</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
       <string>URLTextSearcher</string>
       <key>Arguments</key>
       <dict>


### PR DESCRIPTION
The Haskell Platform was deprecated in 2022 ([details](https://www.haskell.org/platform/)). This PR deprecates the Haskell Platform recipes.