### PR TITLE
Deprecate Eclipse Mars recipes

### DIFF
--- a/Eclipse/EclipseMars.download.recipe
+++ b/Eclipse/EclipseMars.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Eclipse Mars was published in 2015. For newer Eclipse releases, consider switching to the Eclipse recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the Eclipse Mars recipes, and points users to newer versions of Eclipse via the recipes in my homebysix-recipes repo.