### PR TITLE
Deprecate Shotcut recipes

### DIFF
--- a/Shotcut/Shotcut.download.recipe
+++ b/Shotcut/Shotcut.download.recipe
@@ -30,6 +30,15 @@
     <key>Process</key>
     <array>
       <dict>
+        <key>Processor</key>
+        <string>DeprecationWarning</string>
+        <key>Arguments</key>
+        <dict>
+          <key>warning_message</key>
+          <string>Consider switching to the Shotcut recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+        </dict>
+      </dict>
+      <dict>
         <key>Arguments</key>
         <dict>
           <key>github_repo</key>


### PR DESCRIPTION
The Shotcut recipes in this repo are redandant with the ones in dataJAR-recipes, but the dataJAR recipes offer code signature verification, which is a good practice. This PR deprecates the Shotcut recipes and points users to the dataJAR-recipes repo instead.
