### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/DivergentMedia/EditReady.pkg.recipe
+++ b/DivergentMedia/EditReady.pkg.recipe
@@ -51,8 +51,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/GanttProject/GanttProject.pkg.recipe
+++ b/GanttProject/GanttProject.pkg.recipe
@@ -55,8 +55,6 @@
                           <string>%RECIPE_CACHE_DIR%</string>
                           <key>id</key>
                           <string>net.sourceforge.ganttproject.pkg</string>
-                          <key>options</key>
-                          <string>purge_ds_store</string>
                           <key>chown</key>
                           <array>
                                   <dict>

--- a/Lightworks/Lightworks.pkg.recipe
+++ b/Lightworks/Lightworks.pkg.recipe
@@ -68,8 +68,6 @@
           <string>%NAME%-%version%</string>
           <key>id</key>
           <string>com.editshare.lightworks.pkg</string>
-          <key>options</key>
-          <string>purge_ds_store</string>
           <key>chown</key>
           <array>
             <dict>

--- a/TimeOut/TimeOut.pkg.recipe
+++ b/TimeOut/TimeOut.pkg.recipe
@@ -68,8 +68,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>ch.sudo.TimeOut</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/oXygenXMLEditor/oXygenXMLEditor.pkg.recipe
+++ b/oXygenXMLEditor/oXygenXMLEditor.pkg.recipe
@@ -73,8 +73,6 @@
             <string>%pkgroot%</string>
             <key>id</key>
             <string>%PKGID%</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._