### PR TITLE
Fix download recipe for Google Cloud SDK

### DIFF
--- a/Google_Cloud_SDK/Google_Cloud_SDK.download.recipe
+++ b/Google_Cloud_SDK/Google_Cloud_SDK.download.recipe
@@ -22,14 +22,15 @@
   <string>uk.ac.ox.orchard.download.Google_Cloud_SDK</string>
   <key>Input</key>
   <dict>
+    <!-- ARCH should be either arm or x86_64 -->
+    <key>ARCH</key>
+    <string>arm</string>
     <key>NAME</key>
     <string>Google_Cloud_SDK</string>
     <key>BASE_URL</key>
     <string>https://cloud.google.com/sdk/docs/quickstart-macos</string>
-    <key>PKG_SEARCH_PATTERN</key>
-    <string>href="(?P&lt;pkgurl&gt;http[^"]+-darwin-x86_64.tar.gz)"</string>
     <key>VERSION_SEARCH_PATTERN</key>
-    <string>&lt;h2[^\&gt;]+version\s\((?P&lt;version&gt;[0-9\.]{2,})\)</string>
+    <string>Install gcloud CLI version (?P&lt;version&gt;[0-9\.]{2,})</string>
   </dict>
   <key>Process</key>
   <array>
@@ -46,24 +47,13 @@
     </dict>
     <dict>
       <key>Processor</key>
-      <string>URLTextSearcher</string>
-      <key>Arguments</key>
-      <dict>
-        <key>url</key>
-        <string>%BASE_URL%</string>
-        <key>re_pattern</key>
-        <string>%PKG_SEARCH_PATTERN%</string>
-      </dict>
-    </dict>
-    <dict>
-      <key>Processor</key>
       <string>URLDownloader</string>
       <key>Arguments</key>
       <dict>
         <key>url</key>
-        <string>%pkgurl%</string>
+<string>https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-%ARCH%.tar.gz</string>
       </dict>
-    </dict>
+    </dict> 
     <dict>
       <key>Processor</key>
       <string>EndOfCheckPhase</string>


### PR DESCRIPTION
## Details of PR
The current recipe is failing with
```
Processor: URLTextSearcher: Error: No match found on URL: https://cloud.google.com/sdk/docs/quickstart-macos
```
I believe this is because Google changed how the version gets displayed in the HTML code.

I also noticed that there are static (not version-specific) URLs for Intel and Silicon .tar.gz files, so rather than searching for a URL using regex, this PR suggests using the static URL directly, with a new `ARCH` input to specify `arm` or `x86_64`, with `arm` as the default, since Apple will stop supporting Intel completely with macOS 27.

## Testing Done
### Intel
```
autopkg run -v uk.ac.ox.orchard.download.Google_Cloud_SDK
Processing uk.ac.ox.orchard.download.Google_Cloud_SDK...
WARNING: uk.ac.ox.orchard.download.Google_Cloud_SDK is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 550.0.0
URLTextSearcher: Found matching text (match): 550.0.0
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 16 Dec 2025 14:56:36 GMT
URLDownloader: Storing new ETag header: "53489d8"
URLDownloader: Downloaded /Users/username/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.Google_Cloud_SDK/downloads/google-cloud-cli-darwin-x86_64.tar.gz
EndOfCheckPhase
Receipt written to /Users/username/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.Google_Cloud_SDK/receipts/uk.ac.ox.orchard.download-receipt-20260105-102921.plist

The following new items were downloaded:
    Download Path                                                                                                                  
    -------------                                                                                                                  
    /Users/username/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.Google_Cloud_SDK/downloads/google-cloud-cli-darwin-x86_64.tar.gz  
```
### Silicon
```
autopkg run -v uk.ac.ox.orchard.download.Google_Cloud_SDK
Processing uk.ac.ox.orchard.download.Google_Cloud_SDK...
WARNING: uk.ac.ox.orchard.download.Google_Cloud_SDK is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 550.0.0
URLTextSearcher: Found matching text (match): 550.0.0
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 16 Dec 2025 14:56:36 GMT
URLDownloader: Storing new ETag header: "53489d6"
URLDownloader: Downloaded /Users/username/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.Google_Cloud_SDK/downloads/google-cloud-cli-darwin-arm.tar.gz
EndOfCheckPhase
Receipt written to /Users/username/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.Google_Cloud_SDK/receipts/uk.ac.ox.orchard.download-receipt-20260105-102857.plist

The following new items were downloaded:
    Download Path                                                                                                               
    -------------                                                                                                               
    /Users/username/Library/AutoPkg/Cache/uk.ac.ox.orchard.download.Google_Cloud_SDK/downloads/google-cloud-cli-darwin-arm.tar.gz  
```